### PR TITLE
Create a new MutuallyExclusive callback group for every timer, use a multithreaded executor

### DIFF
--- a/ros2/src/airsim_ros_pkgs/include/airsim_ros_wrapper.h
+++ b/ros2/src/airsim_ros_pkgs/include/airsim_ros_wrapper.h
@@ -348,6 +348,11 @@ private:
     rclcpp::TimerBase::SharedPtr airsim_control_update_timer_;
     rclcpp::TimerBase::SharedPtr airsim_lidar_update_timer_;
 
+    /// Callback groups
+    std::vector<rclcpp::CallbackGroup::SharedPtr> airsim_img_callback_groups_;
+    rclcpp::CallbackGroup::SharedPtr airsim_control_callback_group_;
+    std::vector<rclcpp::CallbackGroup::SharedPtr> airsim_lidar_callback_groups_;
+
     typedef std::pair<std::vector<ImageRequest>, std::string> airsim_img_request_vehicle_name_pair;
     std::vector<airsim_img_request_vehicle_name_pair> airsim_img_request_vehicle_name_pair_vec_;
     std::vector<image_transport::Publisher> image_pub_vec_;

--- a/ros2/src/airsim_ros_pkgs/src/airsim_node.cpp
+++ b/ros2/src/airsim_ros_pkgs/src/airsim_node.cpp
@@ -1,35 +1,19 @@
 #include <rclcpp/rclcpp.hpp>
 #include "airsim_ros_wrapper.h"
 
-int main(int argc, char** argv)
-{
+int main(int argc, char **argv) {
     rclcpp::init(argc, argv);
     rclcpp::NodeOptions node_options;
     node_options.automatically_declare_parameters_from_overrides(true);
-    std::shared_ptr<rclcpp::Node> nh = rclcpp::Node::make_shared("airsim_node", node_options);
-    std::shared_ptr<rclcpp::Node> nh_img = nh->create_sub_node("img");
-    std::shared_ptr<rclcpp::Node> nh_lidar = nh->create_sub_node("lidar");
+    std::shared_ptr <rclcpp::Node> nh = rclcpp::Node::make_shared("airsim_node", node_options);
+    std::shared_ptr <rclcpp::Node> nh_img = nh->create_sub_node("img");
+    std::shared_ptr <rclcpp::Node> nh_lidar = nh->create_sub_node("lidar");
     std::string host_ip;
     nh->get_parameter("host_ip", host_ip);
     AirsimROSWrapper airsim_ros_wrapper(nh, nh_img, nh_lidar, host_ip);
-
-    if (airsim_ros_wrapper.is_used_img_timer_cb_queue_) {
-        rclcpp::executors::SingleThreadedExecutor executor;
-        executor.add_node(nh_img);
-        while (rclcpp::ok()) {
-            executor.spin();
-        }
-    }
-
-    if (airsim_ros_wrapper.is_used_lidar_timer_cb_queue_) {
-        rclcpp::executors::SingleThreadedExecutor executor;
-        executor.add_node(nh_lidar);
-        while (rclcpp::ok()) {
-            executor.spin();
-        }
-    }
-
-    rclcpp::spin(nh);
+    rclcpp::executors::MultiThreadedExecutor executor;
+    executor.add_node(nh);
+    executor.spin();
 
     return 0;
 }


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: https://github.com/microsoft/AirSim/issues/4428  <!-- add this line for each issue your PR solves. -->
Fixes: https://github.com/microsoft/AirSim/issues/4569#issuecomment-1165480040
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
This will fix the issue by using a multithreaded executor and adding a MutuallyExclusive callback group to every lidar, camera, and airsim control timer. That way they can all execute in parallel and not block each other. Also removed unreachable code in airsim_node.cpp.
This pr also fixes the issue of timestamps being mixed up, the previous iteration used reentrant callbacks which allowed out-of-order execution of timers.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Added a settings file with multiple cameras and a lidar, did a /airsim_node/local_position_goal service call.

## Screenshots (if appropriate):
The following are two videos depicting ros2 performance with and without the fixes:
https://drive.google.com/file/d/1uIuTfWGhaD56h-wfzxXaOMoVkZL451wI/view?usp=sharing
https://drive.google.com/file/d/1M9JUGOquZmnV6HBqtH7uRjbOCeHgpJfi/view?usp=share_link