### PR TITLE
Bugfix: Update RHI Buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ multi-agent autonomous systems. Check it out here: [SWARM Developer System](http
 Moving forward, we are now using Unreal Engine 5 version 5.03 or greater! If you
 want to use UE4.27, you can use the branch `ue4.27`.
   
+## Unreal Engine Version for Main Branch
+The main branch of this repository **only** supports Unreal Engine 5.2! Please see our other branches
+for other versions that we support.
+  
 ## Currently Supported Operating Systems
 Below are the list of officially supported Operating Systems, with full Unreal Engine support:
 ### Windows

--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -494,9 +494,9 @@ std::vector<msr::airlib::MeshPositionVertexBuffersResponse> UAirBlueprintLib::Ge
             ENQUEUE_RENDER_COMMAND(GetVertexBuffer)
             (
                 [vertex_buffer, data](FRHICommandListImmediate& RHICmdList) {
-                    FVector* indices = (FVector*)RHILockVertexBuffer(vertex_buffer->VertexBufferRHI, 0, vertex_buffer->VertexBufferRHI->GetSize(), RLM_ReadOnly);
+                    FVector* indices = (FVector*)RHILockBuffer(vertex_buffer->VertexBufferRHI, 0, vertex_buffer->VertexBufferRHI->GetSize(), RLM_ReadOnly);
                     memcpy(data, indices, vertex_buffer->VertexBufferRHI->GetSize());
-                    RHIUnlockVertexBuffer(vertex_buffer->VertexBufferRHI);
+                    RHIUnlockBuffer(vertex_buffer->VertexBufferRHI);
                 });
 
 #if ((ENGINE_MAJOR_VERSION > 4) || (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION >= 27))
@@ -516,9 +516,9 @@ std::vector<msr::airlib::MeshPositionVertexBuffersResponse> UAirBlueprintLib::Ge
                 ENQUEUE_RENDER_COMMAND(GetIndexBuffer)
                 (
                     [IndexBuffer, data_ptr](FRHICommandListImmediate& RHICmdList) {
-                        uint16_t* indices = (uint16_t*)RHILockIndexBuffer(IndexBuffer->IndexBufferRHI, 0, IndexBuffer->IndexBufferRHI->GetSize(), RLM_ReadOnly);
+                        uint16_t* indices = (uint16_t*)RHILockBuffer(IndexBuffer->IndexBufferRHI, 0, IndexBuffer->IndexBufferRHI->GetSize(), RLM_ReadOnly);
                         memcpy(data_ptr, indices, IndexBuffer->IndexBufferRHI->GetSize());
-                        RHIUnlockIndexBuffer(IndexBuffer->IndexBufferRHI);
+                        RHIUnlockBuffer(IndexBuffer->IndexBufferRHI);
                     });
 
                 //Need to force the render command to go through cause on the next iteration the buffer no longer exists
@@ -539,9 +539,9 @@ std::vector<msr::airlib::MeshPositionVertexBuffersResponse> UAirBlueprintLib::Ge
                 ENQUEUE_RENDER_COMMAND(GetIndexBuffer)
                 (
                     [IndexBuffer, data_ptr](FRHICommandListImmediate& RHICmdList) {
-                        uint32_t* indices = (uint32_t*)RHILockIndexBuffer(IndexBuffer->IndexBufferRHI, 0, IndexBuffer->IndexBufferRHI->GetSize(), RLM_ReadOnly);
+                        uint32_t* indices = (uint32_t*)RHILockBuffer(IndexBuffer->IndexBufferRHI, 0, IndexBuffer->IndexBufferRHI->GetSize(), RLM_ReadOnly);
                         memcpy(data_ptr, indices, IndexBuffer->IndexBufferRHI->GetSize());
-                        RHIUnlockIndexBuffer(IndexBuffer->IndexBufferRHI);
+                        RHIUnlockBuffer(IndexBuffer->IndexBufferRHI);
                     });
 
                 FlushRenderingCommands();


### PR DESCRIPTION
## Description
- Renames the Index and Vertex buffers for the RHI system
- Thanks to Dany Shapa for the fixes!

Fixes:
- Depreciation warnings that the UE compiler treats as errors

## How Has This Been Tested?
- Built, compiled and run