### PR TITLE
Make pd position controller not block velocity commands after a positional command

### DIFF
--- a/ros2/src/airsim_ros_pkgs/src/pd_position_controller_simple.cpp
+++ b/ros2/src/airsim_ros_pkgs/src/pd_position_controller_simple.cpp
@@ -291,8 +291,8 @@ void PIDPositionController::update_control_cmd_timer_cb()
         }
     }
 
-    // only compute and send control commands for hovering / moving to pose, if we received a goal at least once in the past
-    if (got_goal_once_) {
+    // only compute and send control commands for hovering / moving to pose, if we currently have a goal
+    if (has_goal_) {
         compute_control_cmd();
         enforce_dynamic_constraints();
         publish_control_cmd();


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

 <!-- add this line for each issue your PR solves. -->
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
When using ros2 with simple pd position controller, if a goal is issued once, then velocity commands will stop working since pd controller will send commands even if it doesn't have a goal.
<!-- Describe what your PR is about. -->

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
- Send goal (takeoff, goto)
- Issue velocity command
- The command works with this fix

## Screenshots (if appropriate):