### PR TITLE
Fix issue related Sun Prop checking with Minor Versions

### DIFF
--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -226,7 +226,7 @@ void ASimModeBase::initializeTimeOfDay()
         static const FName sun_prop_name(TEXT("Directional light actor"));
         auto* p = sky_sphere_class_->FindPropertyByName(sun_prop_name);
 
-#if ENGINE_MINOR_VERSION > 24
+#if ((ENGINE_MAJOR_VERSION > 4) || (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION >= 27))
         FObjectProperty* sun_prop = CastFieldChecked<FObjectProperty>(p);
 #else
         FObjectProperty* sun_prop = Cast<FObjectProperty>(p);


### PR DESCRIPTION


## Fixes:
#59 

## About
- Adds a Major version check to the SunProp element to prevent UE from attempting to load the wrong version.

## How Has This Been Tested?
- Compiled and confirmed no issues on a Windows 10 build

