### PR TITLE
Update types.py to fix issues with 'bad cast' RPCError

### DIFF
--- a/PythonClient/airsim/types.py
+++ b/PythonClient/airsim/types.py
@@ -12,7 +12,14 @@ class MsgpackMixin:
         return "<" + type(self).__name__ + "> " + pformat(vars(self), indent=4, width=1)
 
     def to_msgpack(self, *args, **kwargs):
-        return self.__dict__
+        res = []
+        for index, (attr_name, attr_type) in enumerate(self.attribute_order):
+            attr_val = getattr(self, attr_name)
+            if issubclass(attr_type, MsgpackMixin):                
+                res.append(attr_type.to_msgpack(attr_val))
+            else:
+                res.append(attr_val)
+        return res
 
     @classmethod
     def from_msgpack(cls, encoded):
@@ -438,6 +445,7 @@ class ImageResponse(MsgpackMixin):
     image_data_uint8 = np.uint8(0)
     image_data_float = 0.0
     camera_position = Vector3r()
+    camera_name = ''
     camera_orientation = Quaternionr()
     time_stamp = np.uint64(0)
     message = ''
@@ -451,6 +459,7 @@ class ImageResponse(MsgpackMixin):
         ('image_data_uint8', np.ndarray),
         ('image_data_float', float),
         ('camera_position', Vector3r),
+        ('camera_name', str),
         ('camera_orientation', Quaternionr),
         ('time_stamp', np.uint64),
         ('message', str),


### PR DESCRIPTION
It looks like someone started transitioning the RPC messages to be array based instead of dict based but they didn't finish the job. 

I haven't verified that all the types match between `types.py` and the structures defined in `RpcLibAdaptorsBase.hpp`, but I found at least one error in `ImageResponse` (missing the new `camera_name` attribute) so there very well could be others.

<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #100 
Fixes: #99 

## About
<!-- Describe what your PR is about. -->
See above

These changes also break backwards compatibility with the `pip install airsim` library. I'd recommend registering a new `codexairsim` plugin with pip and making use of the `ServerVersion` and `ClientVersion` properties.

There's another `airsim` fork by Cosys (https://github.com/Cosys-Lab/Cosys-AirSim), which also works with 5.4 and adds some new features, but for me it breaks other things. Might be helpful to someone.
 
## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
Tested locally. If you want to use this, you'll need to copy the `PythonClient\airsim` files and overwrite the files you installed via `pip install airsim`

## Screenshots (if appropriate):