### PR TITLE
Fixed build.cmd command line argument handling

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -28,16 +28,16 @@ set buildMode=""
 :loop
 IF NOT "%1"=="" (
     IF "%1"=="--Debug" (
-        set buildMode="Debug"
+        set "buildMode=Debug"
         SHIFT
     ) ELSE IF "%1"=="--Release" (
-        set buildMode="Release"
+        set "buildMode=Release"
         SHIFT
     ) ELSE IF "%1"=="--no-full-poly-car" (
-        set noFullPolyCar="y"
+        set "noFullPolyCar=y"
         SHIFT
     ) ELSE IF "%1"=="--RelWithDebInfo" (
-        set buildMode="RelWithDebInfo"
+        set "buildMode=RelWithDebInfo"
         SHIFT
     ) ELSE (
         echo Unknown command line parameter: %1


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: build.cmd command line argument handling

## About
<!-- Describe what your PR is about. -->
Currently, if you specify an explicit build mode to build.cmd using a command line argument such as `--Release`, the value of the variable buildMode gets extra quotation marks around it which breaks the script, i.e. the value becomes `"Release"` when it should be `Release`. The same happens to the variable noFullPolyCar with the command line argument --no-full-poly-car, but this doesn't actually break anything as the exact value of the variable is never inspected. These changes fix the problem.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

The changes have been tested by running `build.cmd --Release`, `build.cmd --Debug`, `build.cmd --RelWithDebInfo` and `build.cmd --no-full-poly-car` in x64 Native Tools Command Prompt for VS 2022 on Windows 10.

## Screenshots (if appropriate):