### PR TITLE
Removed reset world position

### DIFF
--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.cpp
@@ -112,7 +112,9 @@ void ASimModeBase::BeginPlay()
     player_loc = player_start_transform.GetLocation();
     // Move the world origin to the player's location (this moves the coordinate system and adds
     // a corresponding offset to all positions to compensate for the shift)
-    this->GetWorld()->SetNewWorldOrigin(FIntVector(player_loc) + this->GetWorld()->OriginLocation);
+    // and mess up whole level!!!
+    //this->GetWorld()->SetNewWorldOrigin(FIntVector(player_loc) + this->GetWorld()->OriginLocation);
+
     // Regrab the player's position after the offset has been added (which should be 0,0,0 now)
     player_start_transform = fpv_pawn->GetActorTransform();
     global_ned_transform_.reset(new NedTransform(player_start_transform,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes the possibility of using external levels like https://www.unrealengine.com/marketplace/en-US/product/modular-neighborhood-pack

## About
The same problems described here https://forums.unrealengine.com/t/airsim-prevents-low-level-details-crowd-and-traffic-from-being-drawned-in-cityscape-demo/571506/2 

## How Has This Been Tested?
Download https://www.unrealengine.com/marketplace/en-US/product/modular-neighborhood-pack into Colosseum project and run it