### PR TITLE
To euler fix

### DIFF
--- a/PythonClient/airsim/utils.py
+++ b/PythonClient/airsim/utils.py
@@ -51,7 +51,7 @@ def write_file(filename, bstr):
 
 # helper method for converting getOrientation to roll/pitch/yaw
 # https:#en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
-    
+
 def to_eularian_angles(q):
     z = q.z_val
     y = q.y_val
@@ -59,23 +59,24 @@ def to_eularian_angles(q):
     w = q.w_val
     ysqr = y * y
 
-    # roll (x-axis rotation)
-    t0 = +2.0 * (w*x + y*z)
-    t1 = +1.0 - 2.0*(x*x + ysqr)
-    roll = math.atan2(t0, t1)
-
     # pitch (y-axis rotation)
-    t2 = +2.0 * (w*y - z*x)
-    if (t2 > 1.0):
-        t2 = 1
-    if (t2 < -1.0):
-        t2 = -1.0
-    pitch = math.asin(t2)
-
-    # yaw (z-axis rotation)
-    t3 = +2.0 * (w*z + x*y)
-    t4 = +1.0 - 2.0 * (ysqr + z*z)
-    yaw = math.atan2(t3, t4)
+    test = +2.0 * (w*y - z*x)
+    #near -90 or 90 need to be handled different
+    if (abs(test) > 0.99999):
+        pitch = math.pi/2 * test
+        yaw = 2 * math.atan2(z,w) 
+        roll = 0
+    else:
+        #not sigularity
+        pitch = math.asin(test)
+        # roll (x-axis rotation)
+        t0 = +2.0 * (w*x + y*z)
+        t1 = +1.0 - 2.0*(x*x + ysqr)
+        roll = math.atan2(t0, t1)
+        # yaw (z-axis rotation)
+        t3 = +2.0 * (w*z + x*y)
+        t4 = +1.0 - 2.0 * (ysqr + z*z)
+        yaw = math.atan2(t3, t4)
 
     return (pitch, roll, yaw)
 

--- a/PythonClient/airsim/utils.py
+++ b/PythonClient/airsim/utils.py
@@ -61,8 +61,8 @@ def to_eularian_angles(q):
 
     # pitch (y-axis rotation)
     test = +2.0 * (w*y - z*x)
-    #near -90 or 90 need to be handled different
-    if (abs(test) > 0.99999):
+    #pitch near -90 or 90 need to be handled differently
+    if (abs(test) > 0.999999):
         pitch = math.pi/2 * test
         yaw = 2 * math.atan2(z,w) 
         roll = 0
@@ -74,9 +74,9 @@ def to_eularian_angles(q):
         t1 = +1.0 - 2.0*(x*x + ysqr)
         roll = math.atan2(t0, t1)
         # yaw (z-axis rotation)
-        t3 = +2.0 * (w*z + x*y)
-        t4 = +1.0 - 2.0 * (ysqr + z*z)
-        yaw = math.atan2(t3, t4)
+        t2 = +2.0 * (w*z + x*y)
+        t3 = +1.0 - 2.0 * (ysqr + z*z)
+        yaw = math.atan2(t2, t3)
 
     return (pitch, roll, yaw)
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
Issue with to_eularian_angles() method where quaternions with pitches of -90 or 90 would not return the correct values. These pitches need to be handled differently
<!-- Fixes: # -->
<!-- Fixes: # -->

## About
<!-- Describe what your PR is about. -->
Handling the singularity that occurs when when the pitch is -90 or 90, to have to_eularian_angles() work for all rotations.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->
I wrote several test scripts in another branch called to_euler_tests in my fork https://github.com/kcamroccm/Colosseum/tree/to_euler_tests/PythonClient/TMM

There is a pytest unit test in file test_to_euler.py that goes through random orientations with the singularity exactly, near the singularity, and fully random orientations, converts them back and forth using the utils.to_quaternion() and to_eularian_angles() and verifies that they are still equal within a threshold. 

There is also a script  called vision_pawn_rotation.py that I used to verify the conversion visually while connected to an to unreal. This also works with random orientation of the same types used the pytest script 


## Screenshots (if appropriate):