### PR TITLE
Bugfix/macos sequoia 15.5 compillation fix

### DIFF
--- a/Unreal/Plugins/AirSim/Source/AirSim.Build.cs
+++ b/Unreal/Plugins/AirSim/Source/AirSim.Build.cs
@@ -83,6 +83,10 @@ public class AirSim : ModuleRules
         PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "ImageWrapper", "RenderCore", "RHI", "PhysicsCore", "AssetRegistry", "ChaosVehicles", "Landscape", "CinematicCamera" });
         PrivateDependencyModuleNames.AddRange(new string[] { "UMG", "Slate", "SlateCore", "RenderCore" });
 
+        if (Target.Platform == UnrealTargetPlatform.Mac) {
+            PublicDefinitions.Add("MSGPACK_DISABLE_LEGACY_NIL=1");
+        }
+
         //suppress VC++ proprietary warnings
         PublicDefinitions.Add("_SCL_SECURE_NO_WARNINGS=1");
         PublicDefinitions.Add("_CRT_SECURE_NO_WARNINGS=1");

--- a/build.sh
+++ b/build.sh
@@ -10,11 +10,21 @@ cd build
 
 # Check if we are on Mac using the DARWIN environment variable
 if [[ "$(uname)" == "Darwin" ]]; then
-    echo "Building for MacOS"
+
+    # Fix for Unreal/Unity using x86_64/arm64 (Rosetta) on Apple Silicon hardware.
+    CMAKE_VARS=
+    if [[ "$(uname -a)" == *"arm64"* ]]; then
+        echo "Building for MacOS (arm64)"
+        CMAKE_VARS="-DCMAKE_APPLE_SILICON_PROCESSOR=arm64 -DCMAKE_POLICY_VERSION_MINIMUM=3.10"
+    else
+      echo "Building for MacOS (x86_64)"
+        CMAKE_VARS="-DCMAKE_APPLE_SILICON_PROCESSOR=x86_64 -DCMAKE_POLICY_VERSION_MINIMUM=3.10"
+    fi
+
     # llvm@21 gives errors on build
     export CC="$(brew --prefix)/opt/llvm@18/bin/clang"
     export CXX="$(brew --prefix)/opt/llvm@18/bin/clang++"
-    cmake ../cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_APPLE_SILICON_PROCESSOR=arm64 -DCMAKE_POLICY_VERSION_MINIMUM=3.10
+    cmake ../cmake -DCMAKE_BUILD_TYPE=Release $CMAKE_VARS
     #CC=/usr/bin/clang CXX=/usr/bin/clang++ cmake ../cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_APPLE_SILICON_PROCESSOR=arm64
 else
     echo "Building for Linux"

--- a/build.sh
+++ b/build.sh
@@ -8,13 +8,25 @@ build_dir=build
 mkdir -p build
 cd build
 
-CC=/usr/bin/clang-18 CXX=/usr/bin/clang++-18 cmake ../cmake -DCMAKE_CXX_FLAGS='-stdlib=libc++ -I/usr/lib/llvm-17/include/c++/v1~'
+# Check if we are on Mac using the DARWIN environment variable
+if [[ "$(uname)" == "Darwin" ]]; then
+    echo "Building for MacOS"
+    # llvm@21 gives errors on build
+    export CC="$(brew --prefix)/opt/llvm@18/bin/clang"
+    export CXX="$(brew --prefix)/opt/llvm@18/bin/clang++"
+    cmake ../cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_APPLE_SILICON_PROCESSOR=arm64 -DCMAKE_POLICY_VERSION_MINIMUM=3.10
+    #CC=/usr/bin/clang CXX=/usr/bin/clang++ cmake ../cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_APPLE_SILICON_PROCESSOR=arm64
+else
+    echo "Building for Linux"
+    CC=/usr/bin/clang-18 CXX=/usr/bin/clang++-18 cmake ../cmake -DCMAKE_CXX_FLAGS='-stdlib=libc++ -I/usr/lib/llvm-17/include/c++/v1~'
+fi
 
 make -j$(nproc)
 
 cd ..
 
 mkdir -p AirLib/lib/x64/$folder_name
+mkdir -p AirLib/lib/arm64/$folder_name
 mkdir -p AirLib/deps/rpclib/lib
 mkdir -p AirLib/deps/MavLinkCom/lib
 cp $build_dir/output/lib/libAirLib.a AirLib/lib
@@ -23,6 +35,7 @@ cp $build_dir/output/lib/librpc.a AirLib/deps/rpclib/lib/librpc.a
 
 # Update AirLib/lib, AirLib/deps, Plugins folders with new binaries
 rsync -a --delete build/output/lib/ AirLib/lib/x64/$folder_name
+rsync -a --delete build/output/lib/ AirLib/lib/arm64/$folder_name
 rsync -a --delete external/rpclib/$RPC_VERSION_FOLDER/include AirLib/deps/rpclib
 rsync -a --delete MavLinkCom/include AirLib/deps/MavLinkCom
 rsync -a --delete AirLib Unreal/Plugins/AirSim/Source


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: a new finding during building on Mac M1 with Sequoia OS 15.5
Fixes: potentially #110

## About
This PR fixes a building issue on Mac M1: `error: expected unqualified-id: typedef nil_t nil;`
Also added build support for Mac OS (Darwin) using llvm@18

## How Has This Been Tested?
Fixes were tested by running BlocksV2 project in UE5.4 with integrated AirSim Plugin on Mac M1 with Sequoia OS 15.5.
Testing included AirSim integration with ArduPilot SITL and QGroundControl.

## Screenshots (if appropriate):

<img width="1652" height="931" alt="Unreal_Engine_54_compilation_issue_air_sim" src="https://github.com/user-attachments/assets/a2bdc6bf-4a3b-4f2d-a370-1eb02a04eb01" />

<img width="1686" height="936" alt="fix_mac_os_building" src="https://github.com/user-attachments/assets/011e9e32-6c0c-41b6-882a-0f8fced63f0e" />

<img width="1016" height="536" alt="fixed_bug_mac_os" src="https://github.com/user-attachments/assets/2192f518-8227-4737-a60b-1c2f413ecdc9" />

<img width="1532" height="768" alt="air_sim_testing_results_ue54_project_blocks_V2_on_mac_m1_sequoia_15_5_properties" src="https://github.com/user-attachments/assets/c4460985-b3a8-43f5-acad-acf9997a6601" />

<img width="1724" height="1001" alt="air_sim_testing_results_ue54_project_blocks_V2_on_mac_m1_sequoia_15_5_flying" src="https://github.com/user-attachments/assets/059ba8df-b744-42a2-8780-67c66e79fe3f" />





