### PR TITLE
Fix ue5.7.1 packaging

### DIFF
--- a/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
+++ b/Unreal/Plugins/AirSim/Source/AirBlueprintLib.cpp
@@ -27,6 +27,10 @@
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "DetectionComponent.h"
 #include "CineCameraComponent.h"
+#include "AssetRegistry/AssetData.h"
+#include "RawIndexBuffer.h"
+#include "StaticMeshResources.h"
+#include "Engine/Blueprint.h"
 
 /*
 //TODO: change naming conventions to same as other files?

--- a/Unreal/Plugins/AirSim/Source/AirSim.Build.cs
+++ b/Unreal/Plugins/AirSim/Source/AirSim.Build.cs
@@ -135,7 +135,7 @@ public class AirSim : ModuleRules
     private bool AddLibDependency(string LibName, string LibPath, string LibFileName, ReadOnlyTargetRules Target, bool IsAddLibInclude)
     {
         string PlatformString = (Target.Platform == UnrealTargetPlatform.Win64 || Target.Platform == UnrealTargetPlatform.Mac) ? "x64" : "x86";
-        string ConfigurationString = (Target.Configuration == UnrealTargetConfiguration.Debug) ? "Debug" : "Release";
+        string ConfigurationString = (Target.Configuration == UnrealTargetConfiguration.Debug && Target.Type == TargetType.Editor) ? "Debug" : "Release";
         bool isLibrarySupported = false;
 
 

--- a/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/PawnSimApi.cpp
@@ -293,12 +293,12 @@ bool PawnSimApi::testLineOfSightToPoint(const msr::airlib::GeoPoint& lla) const
             if (hit) {
                 // No LOS, so draw red line
                 FLinearColor color{ 1.0f, 0, 0, 0.4f };
-                params_.pawn->GetWorld()->LineBatcher->DrawLine(params_.pawn->GetActorLocation(), target_location, color, SDPG_World, 10, -1);
+                params_.pawn->GetWorld()->GetLineBatcher(UWorld::ELineBatcherType::World)->DrawLine(params_.pawn->GetActorLocation(), target_location, color, SDPG_World, 10, -1);
             }
             else {
                 // Yes LOS, so draw green line
                 FLinearColor color{ 0, 1.0f, 0, 0.4f };
-                params_.pawn->GetWorld()->LineBatcher->DrawLine(params_.pawn->GetActorLocation(), target_location, color, SDPG_World, 10, -1);
+                params_.pawn->GetWorld()->GetLineBatcher(UWorld::ELineBatcherType::World)->DrawLine(params_.pawn->GetActorLocation(), target_location, color, SDPG_World, 10, -1);
             }
         }
     },

--- a/Unreal/Plugins/AirSim/Source/RenderRequest.cpp
+++ b/Unreal/Plugins/AirSim/Source/RenderRequest.cpp
@@ -144,7 +144,7 @@ void RenderRequest::ExecuteTask()
             FRHICommandListImmediate& RHICmdList = GetImmediateCommandList_ForRenderCommand();
             auto rt_resource = params_[i]->render_target->GetRenderTargetResource();
             if (rt_resource != nullptr) {
-                const FTexture2DRHIRef& rhi_texture = rt_resource->GetRenderTargetTexture();
+                const FTextureRHIRef& rhi_texture = rt_resource->GetRenderTargetTexture();
                 FIntPoint size;
                 auto flags = setupRenderResource(rt_resource, params_[i].get(), results_[i].get(), size);
 

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -152,7 +152,7 @@ void ASimHUD::createMainWidget()
     //create main widget
     if (widget_class_ != nullptr) {
         APlayerController* player_controller = this->GetWorld()->GetFirstPlayerController();
-        auto* pawn = player_controller->GetPawn();
+        TObjectPtr<APawn> pawn = player_controller->GetPawn();
         if (pawn) {
             std::string pawn_name = std::string(TCHAR_TO_ANSI(*pawn->GetName()));
             Utils::log(pawn_name);

--- a/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
+++ b/Unreal/Plugins/AirSim/Source/SimMode/SimModeBase.h
@@ -16,6 +16,7 @@
 #include "common/StateReporterWrapper.hpp"
 #include "LoadingScreenWidget.h"
 #include "UnrealImageCapture.h"
+#include "AssetRegistry/AssetData.h"
 #include "SimModeBase.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FLevelLoaded);

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -790,7 +790,7 @@ bool WorldSimApi::testLineOfSightBetweenPoints(const msr::airlib::GeoPoint& lla1
                 color = FLinearColor{ 0, 1.0f, 0, 0.4f };
             }
 
-            simmode_->GetWorld()->PersistentLineBatcher->DrawLine(point1, point2, color, SDPG_World, 4, 999999);
+            simmode_->GetWorld()->GetLineBatcher(UWorld::ELineBatcherType::WorldPersistent)->DrawLine(point1, point2, color, SDPG_World, 4, 999999);
         }
     },
                                              true);

--- a/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
+++ b/Unreal/Plugins/AirSim/Source/WorldSimApi.cpp
@@ -9,6 +9,8 @@
 #include "Runtime/Engine/Classes/Engine/Engine.h"
 #include "Misc/OutputDeviceNull.h"
 #include "ImageUtils.h"
+#include "Engine/Blueprint.h"
+#include "AssetRegistry/AssetData.h"
 #include <cstdlib>
 #include <ctime>
 #include <algorithm>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

<!-- Fixes: # -->
<!-- Fixes: # -->
Fixes: #146 

## About
<!-- Describe what your PR is about. -->
Packaging the plugin with UnrealUAT reveals errors due to missing
headers and a symbol mismatch for a specific target. Missing headers are
added and debug dependency libraries are linked only for debug editor
target, because `UnrealGame-Debug` target packages AutoRTFM module with
the symbol `_ITERATOR_DEBUG_LEVEL=0` which conflicts with AirSim
dependency binaries.

## How Has This Been Tested?
<!-- Please, describe how you have tested your changes to help us incorporate them. -->

Follow the steps at #146 and see that errors are fixed.

## Screenshots (if appropriate):
N/A

## Notes

This PR is based on #144 